### PR TITLE
Test on r-devel on linux instead of mac

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel', vdiffr: false}
           - {os: macOS-latest,   r: '4.0.1', vdiffr: true}
           - {os: windows-latest, r: '4.0',   vdiffr: true}
+          - {os: ubuntu-16.04,   r: 'devel', vdiffr: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '4.0',   vdiffr: true,  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.6',   vdiffr: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}


### PR DESCRIPTION
This is now an option, and hopefully more robust