### PR TITLE
Skip tests if ggplot2 version is too old

### DIFF
--- a/R/scale-colour-sage-b.R
+++ b/R/scale-colour-sage-b.R
@@ -28,9 +28,8 @@
 scale_colour_sage_b <- function(..., option = "royal", low = NULL, high = NULL,
                                 na.value = "grey50", guide = "colourbar",
                                 aesthetics = "colour") {
-  # TODO: replace with CRAN version after next ggplot2 release
-  if (utils::packageVersion("ggplot2") < "3.3.1.9000") {
-    warning("Binned scales are only available in ggplot2 versions >= 3.3.1.9000. Reverting to continuous.") # nolint
+  if (utils::packageVersion("ggplot2") < "3.3.2") {
+    warning("Binned scales are only available in ggplot2 versions >= 3.3.2. Reverting to continuous.") # nolint
     return(
       scale_colour_sage_c(
         ...,
@@ -58,9 +57,8 @@ scale_colour_sage_b <- function(..., option = "royal", low = NULL, high = NULL,
 scale_fill_sage_b <- function(..., option, low = NULL, high = NULL,
                               na.value = "grey50", guide = "colourbar",
                               aesthetics = "fill") {
-  # TODO: replace with CRAN version after next ggplot2 release
-  if (utils::packageVersion("ggplot2") < "3.3.1.9000") {
-    warning("Binned scales are only available in ggplot2 versions >= 3.3.1.9000. Reverting to continuous.") # nolint
+  if (utils::packageVersion("ggplot2") < "3.3.2") {
+    warning("Binned scales are only available in ggplot2 versions >= 3.3.2. Reverting to continuous.") # nolint
     return(
       scale_fill_sage_c(
         ...,

--- a/tests/testthat/test-scale-colour-sage-b.R
+++ b/tests/testthat/test-scale-colour-sage-b.R
@@ -12,6 +12,8 @@ df <- data.frame(
 )
 
 test_that("scale_colour_sage_b creates binned color scale", {
+  skip_if(packageVersion("ggplot2") < "3.3.2")
+
   p <- ggplot(df, aes(x, y)) +
     geom_point(aes(colour = z))
   p1 <- p + scale_colour_sage_b(option = "apple")
@@ -26,6 +28,8 @@ test_that("scale_colour_sage_b creates binned color scale", {
 })
 
 test_that("scale_fill_sage_b creates binned color scale", {
+  skip_if(packageVersion("ggplot2") < "3.3.2")
+
   p <- ggplot(df, aes(x, y)) +
     geom_tile(aes(fill = z))
   p1 <- p + scale_fill_sage_b(option = "apple")
@@ -54,6 +58,7 @@ test_that("binned scale reverts to continuous on older ggplot2 versions", {
 
 test_that("Binned guide is created", {
   skip_if_not_installed("systemfonts")
+  skip_if(packageVersion("ggplot2") < "3.3.2")
 
   dat <- data.frame(x = 1:5, y = 1:5)
   p <- ggplot(dat, aes(x, y, fill = y)) +


### PR DESCRIPTION
Fixes #13. Some tests use features from ggplot2 that are relatively recent. This skips those tests if the ggplot2 version is too old (we already test for the warning that gets raised if a user tries to use the features with an incompatible version).

I've also set the ggplot2 version that raises the warning to the minimum CRAN version of the package now that it's available.