### PR TITLE
Fix pkgdown github actions

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,9 +41,7 @@ jobs:
         run: |
           install.packages("remotes")
           remotes::install_deps(dependencies = TRUE)
-          # Get dev ggplot2 until 3.3.2 is released
-          remotes::install_github("tidyverse/ggplot2")
-          remotes::install_dev("pkgdown")
+          install.packages("pkgdown", type = "binary")
         shell: Rscript {0}
 
       - name: Install package


### PR DESCRIPTION
The pkgdown build is failing due to issues installing pkgdown from source. I think we previously were using dev features that have now been released, so using the binary should fix it and be fine. I also removed the line that installs the development version of GitHub, because the CRAN version now has the features we need.